### PR TITLE
added Figma design link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Resonate-Website
-Resonate Landing Page
+Resonate Landing Page 
+
+[![Figma Design](https://img.shields.io/badge/Figma-Design-%23F24E1E?style=for-the-badge&logo=figma&logoColor=white)](https://www.figma.com/file/b3DxpcvL98arH8Pru0hTEa/Resonate-Landing-Page?type=design&node-id=0%3A1&mode=design&t=IzEKsikv4qAp7jV8-1)


### PR DESCRIPTION
This pull request addresses issue #2  and adds a Figma design link for the Resonate Website landing page in the readme file.

Design -> [Link](https://www.figma.com/file/b3DxpcvL98arH8Pru0hTEa/Resonate-Landing-Page?type=design&node-id=0%3A1&mode=design&t=IzEKsikv4qAp7jV8-1)