### PR TITLE
fix: correct GitHub social link

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -19,10 +19,10 @@ const About = () => {
           <div className="social-links">
             <a href="mailto:contact@aossie.org"><FaEnvelope /></a>
             <a href="https://gitlab.com/aossie"><SiGitlab /></a> 
-            <a href="https://github.com/AOSSIE"><FaGithub /></a>
-            <a href="https://discord.gg/yourlink"><FaDiscord /></a>
+            <a href="https://github.com/AOSSIE-Org"><FaGithub /></a>
+            <a href="https://discord.com/invite/MMZBadkYFm"><FaDiscord /></a>
             <a href="https://twitter.com/aossie_org"><FaTwitter /></a>
-          </div>
+          </div>x
         </div>
       </div>
     </section>

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -22,7 +22,7 @@ const About = () => {
             <a href="https://github.com/AOSSIE-Org"><FaGithub /></a>
             <a href="https://discord.com/invite/MMZBadkYFm"><FaDiscord /></a>
             <a href="https://twitter.com/aossie_org"><FaTwitter /></a>
-          </div>x
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Fixes #39  incorrect GitHub URL in the social links section.

Verified that the updated link redirects correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Updates**
  * Updated social media links in the About section: refreshed GitHub and Discord URLs.

* **Known Issues**
  * Potential text rendering issue in the About section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->