### PR TITLE
Add Share App feature to promote Resonate via system share

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -731,6 +732,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -1540,6 +1542,7 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.15.tgz",
       "integrity": "sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.15",
@@ -3572,7 +3575,6 @@
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
       "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3591,7 +3593,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3606,7 +3607,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
       "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "peer": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
@@ -3615,7 +3615,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3631,7 +3630,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3642,14 +3640,12 @@
     "node_modules/@testing-library/dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3658,7 +3654,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4470,6 +4465,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -4521,6 +4517,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4851,6 +4848,7 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4937,6 +4935,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5758,6 +5757,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -6381,6 +6381,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7324,6 +7325,7 @@
       "version": "8.52.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
       "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7720,6 +7722,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9975,6 +9978,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -12401,6 +12405,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -13187,6 +13192,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -14253,6 +14259,7 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14581,6 +14588,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14730,6 +14738,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -14761,6 +14770,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15176,6 +15186,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -16663,6 +16674,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17042,6 +17054,7 @@
       "version": "5.89.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -17110,6 +17123,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -17159,6 +17173,7 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -17217,6 +17232,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -17586,6 +17602,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",

--- a/src/components/DownloadApp/DownloadApp.css
+++ b/src/components/DownloadApp/DownloadApp.css
@@ -98,3 +98,51 @@
 .share-btn:hover {
   background-color: #1e40af;
 }
+.download-app {
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.store-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.store-btn {
+  padding: 10px 20px;
+  background-color: #2563eb;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.store-btn:hover {
+  background-color: #1e40af;
+}
+
+.share-container {
+  margin-top: 20px;
+}
+
+.share-btn {
+  padding: 10px 20px;
+  background-color: #10b981;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.share-btn:hover {
+  background-color: #059669;
+}
+
+.share-message {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #333;
+}

--- a/src/components/DownloadApp/DownloadApp.css
+++ b/src/components/DownloadApp/DownloadApp.css
@@ -84,3 +84,17 @@
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
+.share-btn {
+  margin-top: 12px;
+  padding: 10px 16px;
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.share-btn:hover {
+  background-color: #1e40af;
+}

--- a/src/components/DownloadApp/DownloadApp.js
+++ b/src/components/DownloadApp/DownloadApp.js
@@ -1,18 +1,19 @@
-import React from 'react';
-import './DownloadApp.css';
-import StoreButton from './StoreButton';
+import React from "react";
+import "./DownloadApp.css";
+import StoreButton from "./StoreButton"; // ✅ import your StoreButton component
 
 const DownloadApp = () => {
+  const playStoreUrl =
+    "https://play.google.com/store/apps/details?id=com.resonate.resonate";
+
   return (
-    <section className="download-app-section">
-      <div className="download-app-card">
-        <h2>Get the Resonate Mobile app.</h2>
-        <div className="store-buttons">
-          <StoreButton 
-            store="google" 
-            url="https://play.google.com/store/apps/details?id=com.resonate.resonate" 
-          />
-        </div>
+    <section className="download-app">
+      <h2>Download Resonate</h2>
+      <p>Get the Resonate app on your mobile device:</p>
+
+      <div className="store-buttons">
+        {/* Use StoreButton instead of separate <a> */}
+        <StoreButton store="google" url={playStoreUrl} />
       </div>
     </section>
   );

--- a/src/components/DownloadApp/StoreButton.js
+++ b/src/components/DownloadApp/StoreButton.js
@@ -2,6 +2,21 @@ import React from 'react';
 import { FaApple } from 'react-icons/fa';
 import './DownloadApp.css';
 
+const handleShare = async () => {
+  const shareData = {
+    title: "Resonate App",
+    text: "Check out the Resonate app!",
+    url: "https://play.google.com/store/apps/details?id=com.resonate.resonate"
+  };
+
+  if (navigator.share) {
+    await navigator.share(shareData);
+  } else {
+    await navigator.clipboard.writeText(shareData.url);
+    alert("Link copied to clipboard!");
+  }
+};
+
 const StoreButton = ({ store, url }) => {
   const isGoogle = store === 'google';
   const subtitle = isGoogle ? 'GET IT ON' : 'Download on the';
@@ -27,6 +42,9 @@ const StoreButton = ({ store, url }) => {
       <div className="store-text">
         <span className="store-subtitle">{subtitle}</span>
         <span className="store-title">{title}</span>
+      </div>
+      <div className='share-btn' onClick={handleShare}>
+        Share App
       </div>
     </a>
   );

--- a/src/components/DownloadApp/StoreButton.js
+++ b/src/components/DownloadApp/StoreButton.js
@@ -1,52 +1,93 @@
-import React from 'react';
-import { FaApple } from 'react-icons/fa';
-import './DownloadApp.css';
-
-const handleShare = async () => {
-  const shareData = {
-    title: "Resonate App",
-    text: "Check out the Resonate app!",
-    url: "https://play.google.com/store/apps/details?id=com.resonate.resonate"
-  };
-
-  if (navigator.share) {
-    await navigator.share(shareData);
-  } else {
-    await navigator.clipboard.writeText(shareData.url);
-    alert("Link copied to clipboard!");
-  }
-};
+import React, { useState } from "react";
+import { FaApple } from "react-icons/fa";
+import "./DownloadApp.css";
 
 const StoreButton = ({ store, url }) => {
-  const isGoogle = store === 'google';
-  const subtitle = isGoogle ? 'GET IT ON' : 'Download on the';
-  const title = isGoogle ? 'Google Play' : 'App Store';
+  const [message, setMessage] = useState("");
+
+  const handleShare = async () => {
+    const shareData = {
+      title: "Resonate App",
+      text: "Check out the Resonate app!",
+      url: url,
+    };
+
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+        setMessage("Thanks for sharing! 🚀");
+        return;
+      }
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(url);
+        setMessage("Link copied to clipboard 📋");
+        return;
+      }
+
+      setMessage(
+        "Sharing not supported on this browser. Please copy the link manually."
+      );
+    } catch (error) {
+      if (error.name === "AbortError") {
+        setMessage("Sharing cancelled ❌");
+      } else {
+        console.error(error);
+        setMessage("Unable to share the link ⚠️");
+      }
+    }
+  };
+
+  const isGoogle = store === "google";
+  const subtitle = isGoogle ? "GET IT ON" : "Download on the";
+  const title = isGoogle ? "Google Play" : "App Store";
 
   return (
-    <a 
-      href={url} 
-      target="_blank" 
-      rel="noopener noreferrer" 
-      className="store-badge"
-    >
-      {isGoogle ? (
-        <svg className="store-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3,20.5V3.5C3,2.91 3.34,2.39 3.84,2.15L13.69,12L3.84,21.85C3.34,21.6 3,21.09 3,20.5Z" fill="#4285f4"/>
-          <path d="M16.81,15.12L6.05,21.34L14.54,12.85L16.81,15.12Z" fill="#ea4335"/>
-          <path d="M20.16,10.81C20.5,11.08 20.75,11.5 20.75,12C20.75,12.5 20.5,12.92 20.16,13.19L17.89,14.5L15.39,12L17.89,9.5L20.16,10.81Z" fill="#fbbc04"/>
-          <path d="M6.05,2.66L16.81,8.88L14.54,11.15L6.05,2.66Z" fill="#34a853"/>
-        </svg>
-      ) : (
-        <FaApple className="store-icon" />
-      )}
-      <div className="store-text">
-        <span className="store-subtitle">{subtitle}</span>
-        <span className="store-title">{title}</span>
-      </div>
-      <div className='share-btn' onClick={handleShare}>
+    <div className="store-badge-container">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="store-badge"
+      >
+        {isGoogle ? (
+          <svg
+            className="store-icon"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3,20.5V3.5C3,2.91 3.34,2.39 3.84,2.15L13.69,12L3.84,21.85C3.34,21.6 3,21.09 3,20.5Z"
+              fill="#4285f4"
+            />
+            <path
+              d="M16.81,15.12L6.05,21.34L14.54,12.85L16.81,15.12Z"
+              fill="#ea4335"
+            />
+            <path
+              d="M20.16,10.81C20.5,11.08 20.75,11.5 20.75,12C20.75,12.5 20.5,12.92 20.16,13.19L17.89,14.5L15.39,12L17.89,9.5L20.16,10.81Z"
+              fill="#fbbc04"
+            />
+            <path
+              d="M6.05,2.66L16.81,8.88L14.54,11.15L6.05,2.66Z"
+              fill="#34a853"
+            />
+          </svg>
+        ) : (
+          <FaApple className="store-icon" />
+        )}
+        <div className="store-text">
+          <span className="store-subtitle">{subtitle}</span>
+          <span className="store-title">{title}</span>
+        </div>
+      </a>
+
+      <div className="share-btn" onClick={handleShare}>
         Share App
       </div>
-    </a>
+
+      {message && <p className="share-message">{message}</p>}
+    </div>
   );
 };
 

--- a/src/components/DownloadApp/StoreButton.js
+++ b/src/components/DownloadApp/StoreButton.js
@@ -82,9 +82,7 @@ const StoreButton = ({ store, url }) => {
         </div>
       </a>
 
-      <div className="share-btn" onClick={handleShare}>
-        Share App
-      </div>
+      <button type="button" className="share-btn" onClick={handleShare} aria-label="Share Resonate app link">Share App</button>
 
       {message && <p className="share-message">{message}</p>}
     </div>


### PR DESCRIPTION
### What this PR does
- Adds a "Share App" button that allows users to share the Resonate app link.
- Uses the system share functionality so users can easily share via WhatsApp and other supported platforms.
- Shares the official Google Play Store link for the Resonate mobile app.

### Why this change is needed
- Improves app discoverability by enabling easy sharing.
- Helps users promote Resonate with a single click.
- Follows standard app promotion and sharing practices.

### How to test
1. Run the app locally.
2. Click on the "Share App" button.
3. Select WhatsApp (or any other platform).
4. Verify that the Google Play Store link is shared correctly and opens the app page.

### Screenshots / Demo
- Attached screenshots showing the share flow and WhatsApp preview.
<img width="1919" height="891" alt="Screenshot 2026-02-01 125807" src="https://github.com/user-attachments/assets/98990f48-3831-4b4e-9618-f8c0bd6052fc" />

Fixes #212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Share App" button that uses native sharing with an automatic clipboard fallback and displays success/error messages.

* **UI Content**
  * Simplified download section copy and layout to emphasize the store action and improve clarity.

* **Style**
  * New styles for the download area, store buttons, share controls, and share message to enhance spacing, colors, hover states, and responsive wrapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->