### PR TITLE
Improve Underline Styling for Anchor Tag Buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,16 +7,29 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+a {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  transition:
+    color 0.2s ease,
+    text-decoration-color 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
+}
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 .App {


### PR DESCRIPTION
### 🐛 Anchor Tag Button Underline Styling Issue

**Description**
Anchor (`<a>`) tags styled as buttons are showing an unexpected underline. This breaks visual consistency with other buttons and affects the overall UI polish.

**Steps to Reproduce**

1. Use an anchor tag styled as a button
2. Apply button styles (padding, background, border-radius, etc.)
3. Hover or view the button in the UI

**Actual Behavior**

* The anchor text remains **underlined** (default browser behavior)
* Underline may appear on hover or in normal state

**Expected Behavior**

* Anchor buttons should **not show underline**
* Styling should match regular `<button>` elements

**Impact**

* UI looks inconsistent
* Reduces visual clarity and professional appearance

**Suggested Fix**

* Explicitly remove underline using CSS:

  * `text-decoration: none;`
* Ensure hover and focus states also don’t reintroduce the underline

**Environment**

* Browser: All major browsers
* Component: Anchor tag styled as button

---
[Screencast_20260205_085119.webm](https://github.com/user-attachments/assets/496769b5-090f-4d1a-b734-6deb66dcef7c)
