### PR TITLE
Added AOSSIE text to the copyright in footer

### DIFF
--- a/app/components/Layout/Footer/index.jsx
+++ b/app/components/Layout/Footer/index.jsx
@@ -9,7 +9,7 @@ const Footer = () => {
   return (
     <footer className="footer">
       <div className="footer-container">
-        <div className="copyright">&copy; {currentYear}</div>
+        <div className="copyright">&copy; {currentYear} AOSSIE</div>
         <div className="footer-socials">
           <a
             href="https://github.com/AOSSIE-Org"


### PR DESCRIPTION
## Description

Replaced "copyright 2026" with "copyright 2026 AOSSIE" in the footer.

Fixes #267 

## Type of change

Please delete options that are not relevant.


- [ y] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ y] UI/UX update (design changes, interface improvements)

## How Has This Been Tested?
Tested locally 

Before 
<img width="580" height="268" alt="image" src="https://github.com/user-attachments/assets/c01e4d10-2232-481c-8530-6f523f5b8702" />

After
<img width="253" height="124" alt="image" src="https://github.com/user-attachments/assets/4ca0ce0e-9b0e-4986-afaa-7d227877f590" />


Please include screenshots below if applicable.

## Checklist:

- [ y] My code follows the style guidelines of this project
- [ y] I have performed a self-review of my own code
- [ y] I have commented my code, particularly in hard-to-understand areas
- [y ] I have made corresponding changes to the documentation
- [ y] My changes generate no new warnings
- [ y] I have added tests that prove my fix is effective or that my feature works
- [ y] New and existing unit tests pass locally with my changes
- [ y] Any dependent changes have been merged and published in downstream modules
- [ y] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer copyright text to include organization branding information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->