### PR TITLE
Update footer copyright text to include AOSSIE

### DIFF
--- a/app/components/Layout/Footer/index.jsx
+++ b/app/components/Layout/Footer/index.jsx
@@ -9,7 +9,7 @@ const Footer = () => {
   return (
     <footer className="footer">
       <div className="footer-container">
-        <div className="copyright">&copy; {currentYear}</div>
+        <div className="copyright">&copy; {currentYear} AOSSIE</div>
         <div className="footer-socials">
           <a
             href="https://github.com/AOSSIE-Org"


### PR DESCRIPTION
This PR updates the footer text to include "AOSSIE" in the copyright notice
while keeping the year dynamic.
Fixes #267
Tested locally and verified the updated footer text appears correctly.

<img width="1920" height="1080" alt="Screenshot (99)" src="https://github.com/user-attachments/assets/1bb55719-1593-42c9-87b0-fa8baebc19b7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated footer copyright text to display "© {year} AOSSIE".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->