### PR TITLE
Follow-up of PR #189

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,3 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-    security-updates: true


### PR DESCRIPTION
The security-updates option exists in GitHub repository settings, not in the dependabot.yml file.

Because of this, the current configuration includes an unsupported key and should be corrected.

@M4dhav Please checkout this Patch, it's a follow up of #189 
thankyou

Closes #279 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration settings for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->