### PR TITLE
fix(hero):improve mobile spacing for hero section

### DIFF
--- a/app/components/Hero/Hero.css
+++ b/app/components/Hero/Hero.css
@@ -149,3 +149,22 @@
     margin: 0 auto;
   }
 }
+/* moblie spacing improvements for hero section */
+@media (max-width: 768px) {
+  .hero-content {
+    padding: 1.5rem 1rem;
+  }
+
+  .hero-content h1 {
+    margin-bottom: 1rem;
+  }
+
+  .hero-content p {
+    margin-bottom: 1rem;
+  }
+
+  .hero-buttons {
+    margin-top: 1rem;
+    gap:0.75rem;
+  }
+}


### PR DESCRIPTION
This PR enhances mobile spacing within the hero area to improve readability and touch friendliness on smaller devices.
Within viewports that go below 768px, the spacing between the heading, paragraph, and action buttons was perceived to be slightly tight. This PR adds minor spacing adjustments to improve vertical rhythm and tap friendliness within the mobile breakpoint.
There were no design or layout changes made; only responsive spacing tweaks.

fixes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile responsiveness with improved spacing and padding adjustments for the Hero section on devices with screens up to 768px width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->