### PR TITLE
fix: move themeColor and viewport to viewport export (Next.js 13.4+)

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -18,8 +18,12 @@ export const metadata = {
     apple: "/logo192.png",
   },
   manifest: "/manifest.json",
+};
+
+export const viewport = {
   themeColor: "#000000",
-  viewport: "width=device-width, initial-scale=1",
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({ children }) {


### PR DESCRIPTION
##Description
## 🐛 Fix: Move `themeColor` and `viewport` to Next.js `viewport` export

### Background
Since Next.js 13.4+, viewport-related fields such as `themeColor` and `viewport` were moved from the `metadata` object into a dedicated `viewport` export. Keeping them inside `metadata` triggers a Next.js warning and may prevent the browser from correctly applying these values.

### Changes
- Removed `themeColor` and `viewport` from the `metadata` export
- Added a proper `export const viewport` in `app/layout.js` with:
  - `themeColor`
  - `width`
  - `initialScale`

### Result
- Eliminates Next.js metadata warning
- Ensures correct generation of:
  - `<meta name="theme-color">`
  - `<meta name="viewport">`
- Aligns the project with the Next.js 13.4+ metadata API

### Reference
Next.js docs:  
https://nextjs.org/docs/app/api-reference/functions/generate-viewport