### PR TITLE
Add YouTube Button to Redirect to Official Channel (#314)

### DIFF
--- a/app/components/About/About.jsx
+++ b/app/components/About/About.jsx
@@ -39,7 +39,7 @@ const About = () => {
             <a href="https://x.com/aossie_org">
               <BsTwitterX />
             </a>
-            <a href="https://youtu.be/IWtFc72BNhM?si=LbgN2t3A3pOE4P-Y">
+            <a href="https://youtu.be/IWtFc72BNhM?si=LbgN2t3A3pOE4P-Y" target="_blank">
               <FaYoutube />
             </a>
           </div>

--- a/app/components/About/About.jsx
+++ b/app/components/About/About.jsx
@@ -1,7 +1,7 @@
 import "./About.css";
 import AossieLogo from "../../assets/aossie_logo.png";
 import { SiGitlab } from "react-icons/si";
-import { FaEnvelope, FaGithub, FaDiscord } from "react-icons/fa";
+import { FaEnvelope, FaGithub, FaDiscord, FaYoutube } from "react-icons/fa";
 import { BsTwitterX } from "react-icons/bs";
 
 const About = () => {
@@ -38,6 +38,9 @@ const About = () => {
             </a>
             <a href="https://x.com/aossie_org">
               <BsTwitterX />
+            </a>
+            <a href="https://youtu.be/IWtFc72BNhM?si=LbgN2t3A3pOE4P-Y">
+              <FaYoutube />
             </a>
           </div>
         </div>


### PR DESCRIPTION
### **Description**

This PR adds a YouTube button to the website that redirects users to the official YouTube channel.

The button has been added to the appropriate section (header/footer) following the existing UI design and styling conventions. It opens the YouTube link in a new tab using secure redirection (target="_blank" with rel="noopener noreferrer").

This enhancement improves accessibility to video content, tutorials, and updates, and strengthens community engagement.

Fixes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a YouTube social link in the About section, giving users direct access to the official YouTube channel alongside other social platforms.
  * The link opens the YouTube channel in a new browser tab for a seamless transition without leaving the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->