### PR TITLE
 move themeColor and viewport to viewport export 310

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,3 +1,39 @@
+// import { Raleway } from "next/font/google";
+// import "./globals.css";
+// import NavBar from "./components/Layout/NavBar";
+// import Footer from "./components/Layout/Footer";
+
+// const raleway = Raleway({
+//   subsets: ["latin"],
+//   weight: ["300", "400", "500", "600", "700", "800"],
+//   display: "swap",
+// });
+
+// export const metadata = {
+//   title: "Resonate - Social Voice Platform",
+//   description:
+//     "Resonate is an Open Source social voice platform maintained by AOSSIE. Join rooms, talk to people, and connect with the community.",
+//   icons: {
+//     icon: "/resonate_logo_white.png",
+//     apple: "/resonate_logo_white.png",
+//   },
+//   manifest: "/manifest.json",
+//   themeColor: "#000000",
+//   viewport: "width=device-width, initial-scale=1",
+// };
+
+// export default function RootLayout({ children }) {
+//   return (
+//     <html lang="en">
+//       <body className={raleway.className}>
+//         <NavBar />
+//         {children}
+//         <Footer />
+//       </body>
+//     </html>
+//   );
+// }
+
 import { Raleway } from "next/font/google";
 import "./globals.css";
 import NavBar from "./components/Layout/NavBar";
@@ -18,8 +54,12 @@ export const metadata = {
     apple: "/resonate_logo_white.png",
   },
   manifest: "/manifest.json",
+};
+
+export const viewport = {
   themeColor: "#000000",
-  viewport: "width=device-width, initial-scale=1",
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({ children }) {


### PR DESCRIPTION
## Changes Made
- Removed `themeColor` and `viewport` from `metadata` export
- Added separate `viewport` export in `app/layout.js`
- Fixes Next.js 13.4+ warning about unsupported metadata fields

## Warning Fixed
⚠ Unsupported metadata themeColor is configured in metadata export
⚠ Unsupported metadata viewport is configured in metadata export 
@M4dhav  please review this Pr

